### PR TITLE
2.1.6 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
     }
 }
 
-version = "2.1.5"
+version = "2.1.6"
 group= "com.zerofall.ezstorage2"
 archivesBaseName = "ezstorage"
 

--- a/src/main/java/com/zerofall/ezstorage/EZStorage.java
+++ b/src/main/java/com/zerofall/ezstorage/EZStorage.java
@@ -21,6 +21,7 @@ import com.zerofall.ezstorage.init.EZItems;
 import com.zerofall.ezstorage.network.EZNetwork;
 import com.zerofall.ezstorage.proxy.CommonProxy;
 import com.zerofall.ezstorage.ref.EZTab;
+import com.zerofall.ezstorage.ref.Log;
 import com.zerofall.ezstorage.ref.RefStrings;
 import com.zerofall.ezstorage.util.EZStorageUtils;
 
@@ -61,6 +62,7 @@ public class EZStorage {
     @EventHandler
     public void postInit(FMLPostInitializationEvent event) {
     	EZStorageUtils.getModNameFromID(RefStrings.MODID); // build the mod map
+    	Log.logger.info("Loading complete.");
     }
     
 }

--- a/src/main/java/com/zerofall/ezstorage/config/EZConfig.java
+++ b/src/main/java/com/zerofall/ezstorage/config/EZConfig.java
@@ -1,6 +1,7 @@
 package com.zerofall.ezstorage.config;
 
 import com.zerofall.ezstorage.EZStorage;
+import com.zerofall.ezstorage.ref.Log;
 
 import net.minecraftforge.common.config.Configuration;
 
@@ -16,6 +17,7 @@ public class EZConfig {
 	public static boolean enableTerminal;
 	public static boolean enableSecurity;
 	public static boolean enableSearchModes;
+	public static boolean enableOpOverride;
 
 	public static void syncConfig() {
 		final Configuration config = EZStorage.config;
@@ -34,7 +36,10 @@ public class EZConfig {
 		enableSecurity = config.getBoolean("Enable Security", OPTIONS, true, "Should the security features be enabled?");
 		enableSearchModes = config.getBoolean("Enable Search Modes", OPTIONS, true, 
 				"Should '$' in front of a term search ore dictionary names, '@' search mod ids and names, and '%' search creative tab names?");
+		enableOpOverride = config.getBoolean("Enable Op Override", OPTIONS, true,
+				"Should a server op with permission level 2+ in creative mode be able to override the security of systems on their server?");
 
 		if(config.hasChanged()) config.save();
+		Log.logger.info("Configuration loaded.");
 	}
 }

--- a/src/main/java/com/zerofall/ezstorage/ref/Log.java
+++ b/src/main/java/com/zerofall/ezstorage/ref/Log.java
@@ -1,0 +1,8 @@
+package com.zerofall.ezstorage.ref;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class Log {
+	public static final Logger logger = LogManager.getLogger(RefStrings.NAME);
+}

--- a/src/main/java/com/zerofall/ezstorage/ref/RefStrings.java
+++ b/src/main/java/com/zerofall/ezstorage/ref/RefStrings.java
@@ -2,8 +2,8 @@ package com.zerofall.ezstorage.ref;
 
 public class RefStrings {
 	public static final String MODID = "ezstorage";
-	public static final String NAME = "EZ Storage 2";
-	public static final String VERSION = "2.1.5";
+	public static final String NAME = "EZStorage 2";
+	public static final String VERSION = "2.1.6";
 	public static final String CLIENT_PROXY = "com.zerofall.ezstorage.proxy.ClientProxy";
 	public static final String SERVER_PROXY = "com.zerofall.ezstorage.proxy.CommonProxy";
 }

--- a/src/main/java/com/zerofall/ezstorage/tileentity/TileEntityStorageCore.java
+++ b/src/main/java/com/zerofall/ezstorage/tileentity/TileEntityStorageCore.java
@@ -35,8 +35,6 @@ import com.zerofall.ezstorage.util.ItemGroup.EnumSortMode;
 /** The storage core tile entity */
 public class TileEntityStorageCore extends EZTileEntity {
 	
-	public static Logger log = FMLLog.getLogger();
-	
 	public EZInventory inventory;
 	
 	Set<BlockRef> multiblock = new HashSet<BlockRef>();

--- a/src/main/java/com/zerofall/ezstorage/util/SecurityOverrideHelper.java
+++ b/src/main/java/com/zerofall/ezstorage/util/SecurityOverrideHelper.java
@@ -1,0 +1,48 @@
+package com.zerofall.ezstorage.util;
+
+import java.util.List;
+
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.server.management.PlayerList;
+import net.minecraft.util.text.TextComponentString;
+
+import com.zerofall.ezstorage.ref.Log;
+import com.zerofall.ezstorage.ref.RefStrings;
+import com.zerofall.ezstorage.tileentity.TileEntitySecurityBox.SecurePlayer;
+
+/** Helps with overrides for the security system */
+public class SecurityOverrideHelper {
+	
+	/** Returns true if the given player is opped and has at least level 2 permissions */
+	public static boolean isPlayerOpLv2(EntityPlayerMP p) {
+		return getPlayerOpLevel(p) >= 2;
+	}
+	
+	/** Players with op permission levels over zero are ops. */
+	public static int getPlayerOpLevel(EntityPlayerMP p) {
+		try {
+			return p.getServer().getPlayerList().getOppedPlayers().getEntry(p.getGameProfile()).getPermissionLevel();
+		} catch(NullPointerException npe) {
+			return 0;
+		}
+	}
+	
+	/** Sends the op intervention notification */
+	public static void sendOpNotification(EntityPlayerMP op, List<SecurePlayer> securePlayers) {
+		String to = "Operator " + op.getName() + " has overridden your " + RefStrings.NAME + " system lockout.";
+		String from = "You have overridden the lockout to the " + RefStrings.NAME + " system owned by " + securePlayers.get(0).name + ".";
+		sendMessageToSecurePlayers(to, from, securePlayers, op);
+		Log.logger.info("Operator " + op.getName() + " has overridden the lockout to the storage system owned by " + securePlayers.get(0).name + ".");
+	}
+	
+	/** Sends a chat message to a list of secure players from another player */
+	public static void sendMessageToSecurePlayers(String chat, String chatSender, Iterable<SecurePlayer> list, EntityPlayerMP from) {
+		PlayerList pl = from.getServer().getPlayerList();
+		for(SecurePlayer p : list) {
+			EntityPlayerMP match = pl.getPlayerByUsername(p.name);
+			if(match != null) match.addChatMessage(new TextComponentString(chat));
+		}
+		from.addChatMessage(new TextComponentString(chatSender));
+	}
+
+}

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,7 +1,7 @@
 [
 {
   "modid": "ezstorage",
-  "name": "EZ Storage 2",
+  "name": "EZStorage 2",
   "description": "Storage: Simplified again.",
   "version": "${version}",
   "mcversion": "${mcversion}",


### PR DESCRIPTION
+ Added security overrides: opped players in creative mode (with at
least level 2 permissions) can now interact with their users' locked
systems if need be. This can be disabled in the config.
> Changed mod name (not mod ID!) from "EZ Storage 2" to "EZStorage 2".