### PR TITLE
Fixed a bug where vanilla inventory tooltips would not render

### DIFF
--- a/src/main/java/com/zerofall/ezstorage/gui/client/GuiStorageCore.java
+++ b/src/main/java/com/zerofall/ezstorage/gui/client/GuiStorageCore.java
@@ -298,6 +298,8 @@ public class GuiStorageCore extends GuiContainerEZ {
 				}
 			}
 		}
+
+		this.renderHoveredToolTip(mouseX, mouseY);
 	}
 
 	/** Custom tooltips have the exact amount of items at the bottom */


### PR DESCRIPTION
Vanilla inventory tooltips were not being properly rendered in the Storage Core. This basically fixes it.